### PR TITLE
Added categoryFilter : useful for cookie categories

### DIFF
--- a/OpenTag.js
+++ b/OpenTag.js
@@ -250,7 +250,7 @@ QTag.getLoaders = function (urlFilters, scriptLoaders, url, categoryFilter) {
     return b.priority - a.priority;
   });
   for (i = 0, ii = matchedFilters.length; i < ii; i += 1) {
-    QTag.updateLoaders(matchedFilters[i], loaderKeysSet);
+    QTag.updateLoaders(matchedFilters[i], loaderKeysSet, scriptLoaders, categoryFilter);
   }
   for (i in loaderKeysSet) {
     if (loaderKeysSet.hasOwnProperty(i)) {
@@ -289,7 +289,7 @@ QTag.doesUrlFilterMatch = function (urlFilter, url) {
 /**
  * Update the loader key set with the given filter
  */
-QTag.updateLoaders = function (urlFilter, loaderKeysSet, categoryFilter) {
+QTag.updateLoaders = function (urlFilter, loaderKeysSet, scriptLoaders, categoryFilter) {
   var i, ii, scriptLoaderKeys = urlFilter.scriptLoaderKeys;
   if (urlFilter.filterType === QTag.FILTER_TYPE_INCLUDE) {
     for (i = 0, ii = scriptLoaderKeys.length; i < ii; i += 1) {


### PR DESCRIPTION
Load a tag (& script) only it is belongs to the categoryFilter. That means that for the Cookie Law, it's possible to easily classify tags by categories such as technical (1), analytics(2), advertisement(3) and social(4).. or even more sub categories. So if you decide to prevent a set of tag to load, its easier, just modify the categoryFilter array.

Please check the code !