### PR TITLE
webkitURL is deprecated : replaced by URL on newer versions

### DIFF
--- a/src/js/qubit/opentag/Log.js
+++ b/src/js/qubit/opentag/Log.js
@@ -265,7 +265,7 @@
     }
   };
   
-  var _ssupported = !!Define.global().webkitURL;
+  var _ssupported = !!(Define.global().URL || Define.global().webkitURL);
   /**
    * Use styling by default.
    * @returns {Boolean}


### PR DESCRIPTION
Define.global().webkitURL replaced by (Define.global().URL || Define.global().webkitURL)